### PR TITLE
Added path to .yaml file in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `run` method (called by the main method), registers our `ArtistApiResource` 
 ### Build and run
 We can now build an executable jar. In a terminal, run `mvn package`. Once the build has finished, you should see a fat jar (>10MB) called `restAPI-dropwizard-lab-1.0-SNAPSHOT.jar` in the `target/` folder. Executing this with the parameters `server` and the path to our config file will start up our server:
 ```
-java -jar target/restAPI-dropwizard-lab-1.0-SNAPSHOT.jar server artistApiConfig.yaml
+java -jar target/restAPI-dropwizard-lab-1.0-SNAPSHOT.jar server src/main/resources/artistApiConfig.yaml
 ```
 
 ### Try it out


### PR DESCRIPTION
Without path I get error:
Picked up JAVA_TOOL_OPTIONS: -Xmx2254m
java.io.FileNotFoundException: File artistApiConfig.yaml not found
        at io.dropwizard.configuration.FileConfigurationSourceProvider.open(FileConfigurationSourceProvider.java:18)
        at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:80)
        at io.dropwizard.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:126)
        at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:74)
        at io.dropwizard.cli.Cli.run(Cli.java:78)
        at io.dropwizard.Application.run(Application.java:93)
        at ie.gmit.ds.ArtistApiApplication.main(ArtistApiApplication.java:9)